### PR TITLE
Added code to detect and upload .css files

### DIFF
--- a/lib/remote-ftp.js
+++ b/lib/remote-ftp.js
@@ -26,6 +26,10 @@ module.exports = {
 		enableCopyFilename: {
 			type: 'boolean',
 			'default': true
+		},
+		autoUploadCssOnLessSave: {
+			type: 'boolean',
+			'default': false
 		}
 	},
 
@@ -501,6 +505,24 @@ module.exports = {
 					parent.open();
 			} catch (e) {}
 		});
+		
+		var arraypath = local.split("/");
+		if (arraypath[arraypath.length - 1].indexOf(".less") > -1 && atom.config.get('Remote-FTP.autoUploadCssOnLessSave')) {
+			atom.notifications.addSuccess("Additional .css file will be uploaded!")
+	            arraypath[arraypath.length - 1] = "style.css";
+	            cssSlPath = arraypath.join("/");
+	            if (atom.project.contains(local)) {
+	                atom.project.remoteftp.upload(cssSlPath, function(err) {
+	                    try {
+	                        var remoteC = atom.project.remoteftp.toRemote(cssSlPath),
+	                            parentC = atom.project.remoteftp.resolve(Path.dirname(remoteC).replace(/\\/g, '/'));
+	
+	                        if (parentC)
+	                            parentC.open();
+	                    } catch (e) {}
+	                });
+	            }
+        	}
 	},
 
 	omitIgnored: function (locals) {


### PR DESCRIPTION
After saving .less files a file in the same directory with the name "style.css" will be uploaded too.
Added checkbox in settings for control of this feature.

This is a great way for using the [less-autocompile](https://atom.io/packages/less-autocompile) package together with the remote-ftp package in Atom and makes for a seamless workflow.
The header of your main .less file should start like this: ` // out: style.css,…`